### PR TITLE
:green_heart: fix: Update CI to use precise versions of the workflows

### DIFF
--- a/.github/labeler.yml
+++ b/.github/labeler.yml
@@ -1,32 +1,52 @@
 # PR labeler configuration file
 ci:
-  - any: ['.github/**/*', '!.github/ISSUE_TEMPLATE/*', '!.github/pull_request_template.md']
-  - .pre-commit-config.yaml
-  - .pre-commit-config/**/*
+- any:
+  - changed-files:
+    - all-globs-to-any-file: [.github/**/*, '!.github/ISSUE_TEMPLATE/*', '!.github/pull_request_template.md']
+    - any-glob-to-any-file:
+      - .pre-commit-config.yaml
+      - .pre-commit-config
+      - .semrelrc
 
 gitignore:
-  - .gitignore
+- changed-files:
+  - any-glob-to-any-file:
+    - .gitignore
 
 github_actions:
-  - any: ['.github/**/*', '!.github/ISSUE_TEMPLATE/*', '!.github/pull_request_template.md']
+- any:
+  - changed-files:
+    - all-globs-to-any-file: [.github/**/*, '!.github/ISSUE_TEMPLATE/*', '!.github/pull_request_template.md']
+
 
 documentation:
-  - CHANGELOG.md
-  - CODE_OF_CONDUCT.md
-  - CONTRIBUTING.md
-  - LICENSE
-  - SECURITY.md
-  - .github/ISSUE_TEMPLATE/**/*
-  - .github/pull_request_template.md
-  - '**/README.md'
+- any:
+  - changed-files:
+    - any-glob-to-any-file:
+      - CHANGELOG.md
+      - CODE_OF_CONDUCT.md
+      - CONTRIBUTING.md
+      - LICENSE
+      - SECURITY.md
+      - .github/ISSUE_TEMPLATE/**/*
+      - .github/pull_request_template.md
+      - '**/README.md'
 
 configuration:
-  - .pre-commit-config.yaml
-  - .editorconfig
-  - .devcontainer/**/*
+- any:
+  - changed-files:
+    - any-glob-to-any-file:
+      - .devcontainer/**/*
+      - .pre-commit-config.yaml
+      - .editorconfig
+      - justfile
 
 packages:
-  - packages/**/*
+- changed-files:
+  - any-glob-to-any-file:
+    - packages/**/*
 
 scripts:
-  - '*.ps1'
+- changed-files:
+  - any-glob-to-any-file:
+    - '*.ps1'

--- a/.github/workflows/integration.yaml
+++ b/.github/workflows/integration.yaml
@@ -9,12 +9,12 @@ jobs:
     permissions:
       contents: read
       pull-requests: write
-    uses: gsuquet/workflows/.github/workflows/automation-labeler.yml@main
+    uses: gsuquet/workflows/.github/workflows/automation-labeler.yml@v1.0.0
 
   update-package-list:
     permissions:
       contents: write
-    uses: gsuquet/workflows/.github/workflows/integration-modification-script.yml@main
+    uses: gsuquet/workflows/.github/workflows/integration-modification-script.yml@v1.0.0
     with:
       script_path: ./scripts/generate_package_list.sh
       ref: ${{ github.head_ref }}


### PR DESCRIPTION
# Description

- Update the CI to use the [v1.0.0 release](https://github.com/gsuquet/workflows/releases/tag/v1.0.0) of the centralized workflows repository
- Update the labeler configuration file syntax to match the breaking changes introduced in [version 5 of the labeler action](https://github.com/actions/labeler/releases/tag/v5.0.0)

## Type of change

:green_heart: Fix CI build

