### PR TITLE
:green_heart: fix(ci): Use zero trust permissions, add security policy & automate dependencies update

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,26 @@
+version: 2
+updates:
+- package-ecosystem: devcontainers
+  directory: /
+  schedule:
+    interval: weekly
+    day: friday
+  target-branch: main
+  reviewers:
+  - gsuquet
+  assignees:
+  - gsuquet
+  commit-message:
+    prefix: ':technologist: chore(dev):'
+
+- package-ecosystem: github-actions
+  directory: /
+  schedule:
+    interval: weekly
+    day: friday
+  reviewers:
+  - gsuquet
+  assignees:
+  - gsuquet
+  commit-message:
+    prefix: ':green_heart: chore(ci):'

--- a/.github/workflows/integration.yml
+++ b/.github/workflows/integration.yml
@@ -4,42 +4,19 @@ on:
     branches:
       - main
 
-permissions: read-all
+permissions: {}
 
 jobs:
   triage:
     permissions:
-      actions: read
-      checks: read
-      contents: write
-      deployments: read
-      id-token: write
-      issues: read
-      discussions: read
-      packages: read
-      pages: read
+      contents: read
       pull-requests: write
-      repository-projects: read
-      security-events: read
-      statuses: read
-    uses: gsuquet/workflows/.github/workflows/automation-labeler.yml@55560682dc739645e48780690e5c8bfd8500cacb
+    uses: gsuquet/workflows/.github/workflows/automation-labeler.yml@aebb532da1ae58102592b7fc24c073be101326e6
 
   update-package-list:
     permissions:
-      actions: read
-      checks: read
       contents: write
-      deployments: read
-      id-token: write
-      issues: read
-      discussions: read
-      packages: read
-      pages: read
-      pull-requests: read
-      repository-projects: read
-      security-events: read
-      statuses: read
-    uses: gsuquet/workflows/.github/workflows/integration-modification-script.yml@55560682dc739645e48780690e5c8bfd8500cacb
+    uses: gsuquet/workflows/.github/workflows/integration-modification-script.yml@aebb532da1ae58102592b7fc24c073be101326e6
     with:
       script_path: ./scripts/generate_package_list.sh
       ref: ${{ github.head_ref }}

--- a/.github/workflows/security.yml
+++ b/.github/workflows/security.yml
@@ -5,25 +5,16 @@ on:
     branches:
       - main
 
-permissions: read-all
+permissions: {}
 
 jobs:
   ossf-scorecard:
     permissions:
       actions: read
-      checks: read
       contents: read
-      deployments: read
-      id-token: write
-      issues: read
-      discussions: read
-      packages: read
-      pages: read
-      pull-requests: read
-      repository-projects: read
       security-events: write
-      statuses: read
-    uses: gsuquet/workflows/.github/workflows/security-ossf-scorecard.yml@55560682dc739645e48780690e5c8bfd8500cacb
+      id-token: write
+    uses: gsuquet/workflows/.github/workflows/security-ossf-scorecard.yml@aebb532da1ae58102592b7fc24c073be101326e6
     with:
       harden_runner: true
     secrets:

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -1,0 +1,11 @@
+# Security Policy
+
+## Supported Versions
+All versions of this project are currently supported.
+
+| Version | Supported          |
+| ------- | ------------------ |
+| All  | :white_check_mark: |
+
+## Reporting a Vulnerability
+To report a vulnerability, please send an email to [gsuquet@ippon.fr](mailto:gsuquet@ippon.fr).  


### PR DESCRIPTION
# Description

- Dependabot configuration to update the GitHub workflows  
- Use the latest shared workflows version with hardened runners & less default permissions  
- Add a Security policy

## Type of change

:green_heart: CI/CD update  
:memo: Documentation update
